### PR TITLE
Fixed the error in the app when filtering a variabe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Suggests:
     parallel,
     shiny,
     glue,
+    janitor,
     rclipboard,
     testthat
 RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scdhlm
 Title: Estimating Hierarchical Linear Models for Single-Case Designs
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person("James", "Pustejovsky", email = "jepusto@gmail.com", role = c("aut", "cre")),
     person("Man", "Chen", role = "aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# scdhlm 0.5.2
+
+* Fixed bug in shiny app occurring when filtering variable(s) of the input data set.
+
+* Updated shiny app to clean the variable names of the input data.
+
 # scdhlm 0.5.1
 
 * Modified the `Schutte` example dataset to exclude the fourth case, for consistency with the analysis presented in Pustejovsky, Hedges, & Shadish (2014).

--- a/R/scdhlm.R
+++ b/R/scdhlm.R
@@ -48,6 +48,9 @@ shine_scd <- function(dataset = NULL, ...) {
   if (!requireNamespace("readxl", quietly = TRUE)) {
     stop("The scdhlm app requires the readxl package. Please install it.", call. = FALSE)
   }
+  if (!requireNamespace("janitor", quietly = TRUE)) {
+    stop("The scdhlm app requires the janitor package. Please install it.", call. = FALSE)
+  }
   
   uiDir <- system.file("shiny-examples/scdhlm", "ui.R", package = "scdhlm")
   serveDir <- system.file("shiny-examples/scdhlm", "server.R", package = "scdhlm")
@@ -79,4 +82,5 @@ shine_scd <- function(dataset = NULL, ...) {
   
   app <- shiny::shinyApp(ui, server)
   shiny::runApp(app, display.mode = "normal", launch.browser = TRUE)
+  
 }

--- a/R/scdhlm.R
+++ b/R/scdhlm.R
@@ -30,28 +30,16 @@
 
 shine_scd <- function(dataset = NULL, ...) {
   
-  if (!requireNamespace("shiny", quietly = TRUE)) {
-    stop("The scdhlm app requires the shiny package. Please install it.", call. = FALSE)
-  }
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop("The scdhlm app requires the ggplot2 package. Please install it.", call. = FALSE)
-  }
-  if (!requireNamespace("markdown", quietly = TRUE)) {
-    stop("The scdhlm app requires the markdown package. Please install it.", call. = FALSE)
-  }
-  if (!requireNamespace("glue", quietly = TRUE)) {
-    stop("The scdhlm app requires the glue package. Please install it.", call. = FALSE)
-  }
-  if (!requireNamespace("rclipboard", quietly = TRUE)) {
-    stop("The scdhlm app requires the rclipboard package. Please install it.", call. = FALSE)
-  }
-  if (!requireNamespace("readxl", quietly = TRUE)) {
-    stop("The scdhlm app requires the readxl package. Please install it.", call. = FALSE)
-  }
-  if (!requireNamespace("janitor", quietly = TRUE)) {
-    stop("The scdhlm app requires the janitor package. Please install it.", call. = FALSE)
-  }
+  req_pkgs <- c("shiny","ggplot2","markdown","glue","rclipboard","readxl","janitor")
+  missing_pkgs <- unlist(lapply(req_pkgs, check_for_package))
   
+  if (length(missing_pkgs) > 1) {
+    missing_pkgs <- paste(missing_pkgs, collapse = ", ")
+    stop(paste0("The scdhlm app requires the following packages: ", missing_pkgs,". Please install them."), call. = FALSE)
+  } else if (length(missing_pkgs) == 1) {
+    stop(paste("The scdhlm app requires the", missing_pkgs,"package. Please install it."), call. = FALSE)
+  }
+    
   uiDir <- system.file("shiny-examples/scdhlm", "ui.R", package = "scdhlm")
   serveDir <- system.file("shiny-examples/scdhlm", "server.R", package = "scdhlm")
   if (uiDir == "" | serveDir == "") {
@@ -83,4 +71,9 @@ shine_scd <- function(dataset = NULL, ...) {
   app <- shiny::shinyApp(ui, server)
   shiny::runApp(app, display.mode = "normal", launch.browser = TRUE)
   
+}
+
+check_for_package <- function(pkg) {
+  req <- requireNamespace(pkg, quietly = TRUE)
+  if (!req) pkg else NULL
 }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,9 +2,9 @@
 
 This is a re-submission. In this version we have:
 
-* Corrected a unit test that led to an error in the CRAN MKL test.
-* Modified one of the example datasets for consistency with a published analysis.
-* Revised the pre-processing function for consistency with published examples.
+* Corrected a unit test that led to errors in the CRAN checks.
+* Fixed a bug in shiny app when filtering variable(s) of the input data set.
+* Updated shiny app to clean the variable names in the data read-in process.
 
 ## Test environments
 

--- a/inst/shiny-examples/scdhlm/code-chunks/clean-example-nofilter-TR.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/clean-example-nofilter-TR.R
@@ -1,6 +1,12 @@
 # Clean data
+
 dat <- dat[,c("{user_parms}")]
 names(dat) <- c("case","session","phase","outcome")
-dat <- preprocess_SCD(case = case, phase = phase, session = session, outcome = outcome, 
-                      design = "{user_design}", data = dat)
+
+dat <- preprocess_SCD(case = case, 
+                      phase = phase, 
+                      session = session, 
+                      outcome = outcome, 
+                      design = "{user_design}", 
+                      data = dat)
 

--- a/inst/shiny-examples/scdhlm/code-chunks/clean-example-nofilter.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/clean-example-nofilter.R
@@ -1,6 +1,13 @@
 # Clean data
+
 dat <- dat[,c("{user_parms}")]
 names(dat) <- c("case","session","phase","outcome")
-dat <- preprocess_SCD(case = case, phase = phase, session = session, outcome = outcome, 
-                      design = "{user_design}", center = {user_model_center}, data = dat)
+
+dat <- preprocess_SCD(case = case, 
+                      phase = phase, 
+                      session = session, 
+                      outcome = outcome, 
+                      design = "{user_design}", 
+                      center = {user_model_center}, 
+                      data = dat)
 

--- a/inst/shiny-examples/scdhlm/code-chunks/clean-inputdata-nofilter-TR.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/clean-inputdata-nofilter-TR.R
@@ -1,3 +1,9 @@
 # Clean data
-dat <- preprocess_SCD(case = {user_caseID}, phase = {user_phaseID}, session = {user_session}, outcome = {user_outcome}, 
-                      design = "{user_design}", round_session = {user_round}, treatment_name = "{user_treatment}", data = dat)
+dat <- preprocess_SCD(case = {user_caseID}, 
+                      phase = {user_phaseID}, 
+                      session = {user_session}, 
+                      outcome = {user_outcome}, 
+                      design = "{user_design}", 
+                      round_session = {user_round}, 
+                      treatment_name = "{user_treatment}", 
+                      data = dat)

--- a/inst/shiny-examples/scdhlm/code-chunks/clean-inputdata-nofilter.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/clean-inputdata-nofilter.R
@@ -1,3 +1,10 @@
 # Clean data
-dat <- preprocess_SCD(case = {user_caseID}, phase = {user_phaseID}, session = {user_session}, outcome = {user_outcome}, 
-                      design = "{user_design}", center = {user_model_center}, round_session = {user_round}, treatment_name = "{user_treatment}", data = dat)
+dat <- preprocess_SCD(case = {user_caseID}, 
+                      phase = {user_phaseID}, 
+                      session = {user_session}, 
+                      outcome = {user_outcome}, 
+                      design = "{user_design}", 
+                      center = {user_model_center}, 
+                      round_session = {user_round}, 
+                      treatment_name = "{user_treatment}", 
+                      data = dat)

--- a/inst/shiny-examples/scdhlm/code-chunks/load-dat.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/load-dat.R
@@ -1,7 +1,7 @@
-
 # Load data
-dat <- read.table("{user_path}", 
-                  header={user_header}, 
-                  sep= "{user_sep}", 
-                  quote= '{user_quote}', 
-                  stringsAsFactors = FALSE) # Modify the path to the full location of your file
+library(janitor)
+
+dat <- 
+  read.table("{user_path}", header = {user_header}, sep = "{user_sep}", 
+             quote = '{user_quote}', stringsAsFactors = FALSE) %>% # Modify the path to the full location of your file
+  clean_names(case = "parsed")

--- a/inst/shiny-examples/scdhlm/code-chunks/load-excel.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/load-excel.R
@@ -1,5 +1,7 @@
 # Load data
 library(readxl)
+library(janitor)
 
-dat <- read_excel(path = "{user_path}", 
-                  sheet ="{user_sheet}") # Modify the path to the full location of your file
+dat <- 
+  read_excel(path = "{user_path}", sheet = "{user_sheet}") %>% # Modify the path to the full location of your file
+  clean_names(case = "parsed")

--- a/inst/shiny-examples/scdhlm/code-chunks/load-from-function.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/load-from-function.R
@@ -1,3 +1,4 @@
 
 # You're using data that you specified when starting the app.
 # You'll need to read it in yourself and store it in an object called 'dat'.
+# Please use janitor::clean_names(case = "parsed") if the variable names include special character(s).

--- a/inst/shiny-examples/scdhlm/code-chunks/load-from-function.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/load-from-function.R
@@ -1,4 +1,4 @@
 
 # You're using data that you specified when starting the app.
 # You'll need to read it in yourself and store it in an object called 'dat'.
-# Please use janitor::clean_names(case = "parsed") if the variable names include special character(s).
+# Please clean 'dat' with dat <- janitor::clean_names(dat, case = "parsed").

--- a/inst/shiny-examples/scdhlm/code-chunks/load-from-function.R
+++ b/inst/shiny-examples/scdhlm/code-chunks/load-from-function.R
@@ -1,4 +1,6 @@
 
 # You're using data that you specified when starting the app.
 # You'll need to read it in yourself and store it in an object called 'dat'.
-# Please clean 'dat' with dat <- janitor::clean_names(dat, case = "parsed").
+
+# Clean the variable names 
+dat <- janitor::clean_names(dat, case = "parsed").

--- a/inst/shiny-examples/scdhlm/markdown/Accessing_scdhlm.Rmd
+++ b/inst/shiny-examples/scdhlm/markdown/Accessing_scdhlm.Rmd
@@ -23,6 +23,7 @@ In order to run the app on your own computer, you will need to install two piece
     install.packages("shiny")
     install.packages("markdown")
     install.packages("readxl")
+    install.packages("janitor")
     install.packages("scdhlm")
     ```
 

--- a/inst/shiny-examples/scdhlm/markdown/Accessing_scdhlm.md
+++ b/inst/shiny-examples/scdhlm/markdown/Accessing_scdhlm.md
@@ -41,6 +41,7 @@ faster speeds than over the web.
         install.packages("shiny")
         install.packages("markdown")
         install.packages("readxl")
+        install.packages("janitor")
         install.packages("scdhlm")
 
 4.  After all of these packages are installed, type the following

--- a/inst/shiny-examples/scdhlm/server.R
+++ b/inst/shiny-examples/scdhlm/server.R
@@ -3,6 +3,7 @@ library(markdown)
 library(ggplot2)
 library(scdhlm)
 library(readxl)
+library(janitor)
 
 source("mappings.R", local = TRUE)
 source("helper-functions.R", local = TRUE)
@@ -51,7 +52,7 @@ server <-
         
         read.table(inFile$datapath, header=input$header, 
                    sep=input$sep, quote=input$quote,
-                   stringsAsFactors = FALSE)
+                   stringsAsFactors = FALSE) %>% clean_names(case = "parsed")
         
       } else if (input$dat_type == "xlsx") {
         
@@ -60,10 +61,10 @@ server <-
         if (is.null(inFile) || is.null(input$inSelect) || nchar(input$inSelect) == 0) return(NULL)
         
         as.data.frame(readxl::read_xlsx(inFile$datapath, col_names = input$col_names,
-                                sheet = input$inSelect))
+                                sheet = input$inSelect)) %>% clean_names(case = "parsed")
         
       } else if (input$dat_type == "loaded") {
-        dataset
+        dataset %>% clean_names(case = "parsed")
       } 
     })
     

--- a/inst/shiny-examples/scdhlm/server.R
+++ b/inst/shiny-examples/scdhlm/server.R
@@ -52,7 +52,8 @@ server <-
         
         read.table(inFile$datapath, header=input$header, 
                    sep=input$sep, quote=input$quote,
-                   stringsAsFactors = FALSE) %>% clean_names(case = "parsed")
+                   stringsAsFactors = FALSE) %>% 
+          clean_names(case = "parsed")
         
       } else if (input$dat_type == "xlsx") {
         
@@ -60,11 +61,16 @@ server <-
         
         if (is.null(inFile) || is.null(input$inSelect) || nchar(input$inSelect) == 0) return(NULL)
         
-        as.data.frame(readxl::read_xlsx(inFile$datapath, col_names = input$col_names,
-                                sheet = input$inSelect)) %>% clean_names(case = "parsed")
+        readxl::read_xlsx(inFile$datapath, col_names = input$col_names,
+                          sheet = input$inSelect) %>% 
+          clean_names(case = "parsed") %>%
+          as.data.frame()
         
       } else if (input$dat_type == "loaded") {
-        dataset %>% clean_names(case = "parsed")
+        
+        dataset %>% 
+          clean_names(case = "parsed")
+        
       } 
     })
     

--- a/inst/shiny-examples/scdhlm/server.R
+++ b/inst/shiny-examples/scdhlm/server.R
@@ -239,17 +239,21 @@ server <-
         phase <- datFile()[,input$phaseID]
         session <- as.numeric(datFile()[,input$session])
         outcome <- as.numeric(datFile()[,input$outcome])
-        design <- studyDesign()
-        round_session <- if (!is.null(input$round_session)) TRUE else FALSE
-        treatment_name <- input$treatment
-        dat <- preprocess_SCD(case = case, phase = phase, 
-                              session = session, outcome = outcome, 
-                              design = design, round_session = round_session, treatment_name = treatment_name)
+        dat <- data.frame(case = case, phase = phase, session = session, outcome = outcome)
         
         if (!is.null(input$filters)) {
           subset_vals <- sapply(input$filters, function(x) datFile()[[x]] %in% input[[paste0("filter_",x)]])
           dat <- dat[apply(subset_vals, 1, all),]
         } 
+        
+        design <- studyDesign()
+        round_session <- if (!is.null(input$round_session)) TRUE else FALSE
+        treatment_name <- input$treatment
+        dat <- preprocess_SCD(case = dat$case, phase = dat$phase, 
+                              session = dat$session, outcome = dat$outcome, 
+                              design = design, round_session = round_session, treatment_name = treatment_name)
+        
+        
       }
       
       names(dat)[1:4] <- c("case", "phase", "session", "outcome")


### PR DESCRIPTION
This pull request solves the issue #57.

I found another issue from this nazdat.xlsx example. When the data set has nonstandard column names, like the space or parenthesis in nazdat.xlsx, the current replication code in the Syntax tab, if run in R or RStudio, will return a bunch of errors because `preprocess_SCD()`, `lme()`, or `graph_SCD()` functions cannot recognize the variable names. Do you suggest we add backticks to all variable names in the Syntax tab? Or we can throw an error when users specify variable names in the Load tab and ask them to rename the variables.