### PR TITLE
Update tests

### DIFF
--- a/tests/testthat/test_graphing_functions.R
+++ b/tests/testthat/test_graphing_functions.R
@@ -106,7 +106,7 @@ test_that("graph_SCD works for design = 'MBP'", {
   expect_s3_class(Laski_graph2, "ggplot")
   expect_invisible(print(Laski_graph2))
   
-  keys <- setdiff(names(Laski_graph1), c("data","plot_env", "labels","layers"))
+  keys <- setdiff(names(Laski_graph1), c("data","plot_env", "labels","layers", "layout"))
   expect_equal(Laski_graph1[keys], Laski_graph2[keys])
   
 
@@ -126,7 +126,7 @@ test_that("graph_SCD works for design = 'MBP'", {
   expect_s3_class(Laski_graph4, "ggplot")
   expect_invisible(print(Laski_graph4))
   
-  keys <- setdiff(names(Laski_graph1), c("plot_env", "labels","layers"))
+  keys <- setdiff(names(Laski_graph1), c("data","plot_env", "labels","layers", "layout"))
   expect_equal(Laski_graph3[keys], Laski_graph4[keys])
   
 })
@@ -177,7 +177,7 @@ test_that("graph_SCD works for design = 'RMBB'", {
   expect_s3_class(Thiemann_graph4, "ggplot")
   expect_invisible(print(Thiemann_graph4))
   
-  keys <- setdiff(names(Thiemann_graph3), c("data","plot_env", "labels", "layers"))
+  keys <- setdiff(names(Thiemann_graph3), c("data","plot_env", "labels","layers", "layout"))
   expect_equal(Thiemann_graph3[keys], Thiemann_graph4[keys])
   
 })
@@ -233,7 +233,7 @@ test_that("graph_SCD works for design = 'CMB'", {
   expect_s3_class(Bry_graph4, "ggplot")
   expect_invisible(print(Bry_graph4))
   
-  keys <- setdiff(names(Bry_graph3), c("data","plot_env", "labels", "layers"))
+  keys <- setdiff(names(Bry_graph3), c("data","plot_env", "labels","layers", "layout", "guides"))
   expect_equal(Bry_graph3[keys], Bry_graph4[keys])
   
 })


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break scdhlm.

Briefly, we've updated the result object from `ggplot()`, which broke some tests that assumed equility in some plot components. This PR exclude some of the new items from the test of equality.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help scdhlm get out a fix if necessary.